### PR TITLE
ImageLoader.loadTileSet() returns ID of first tile

### DIFF
--- a/Bermuda/Bermuda/ImageLoader.cpp
+++ b/Bermuda/Bermuda/ImageLoader.cpp
@@ -6,8 +6,10 @@ ImageLoader::ImageLoader(SDL_Renderer* renderer)
 	this->renderer = renderer;
 }
 
-void ImageLoader::loadTileset(string filename, double tileWidth, double tileHeight)
+//Returns the first ID of the new tileset images
+int ImageLoader::loadTileset(string filename, double tileWidth, double tileHeight)
 {
+	int startID = images.size() + 1;
 	SDL_Texture* tileSet = IMG_LoadTexture(renderer, (RESOURCEPATH + filename).c_str());
 	tileSets.push_back(tileSet);
 
@@ -40,6 +42,7 @@ void ImageLoader::loadTileset(string filename, double tileWidth, double tileHeig
 		x = 0;
 		y += tileHeight;
 	}
+	return startID;
 }
 
 SDL_Texture* ImageLoader::loadSpriteSheet(string filename)

--- a/Bermuda/Bermuda/ImageLoader.h
+++ b/Bermuda/Bermuda/ImageLoader.h
@@ -14,7 +14,7 @@ private:
 public:
 	ImageLoader(SDL_Renderer* renderer);
 	~ImageLoader();
-	void loadTileset(string filename, double tileWidth, double tileHeight);
+	int loadTileset(string filename, double tileWidth, double tileHeight);
 	SDL_Texture* loadSpriteSheet(string filename);
 	Image* getMapImage(int tileID);
 };


### PR DESCRIPTION
Nu de imageLoader loadTileset() methode het ID returnd van de 1e image uit de tileset, kun je makkelijker in alle klassen tilesets inladen. 
